### PR TITLE
Various improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "dumpster-dip",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "jsonfn": "0.31.0",
         "sunday-driver": "1.0.2",
-        "wtf_wikipedia": "10.0.0",
+        "wtf_wikipedia": "^10.1.4",
         "yargs": "17.4.1"
       },
       "engines": {
@@ -826,9 +826,9 @@
       }
     },
     "node_modules/wtf_wikipedia": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/wtf_wikipedia/-/wtf_wikipedia-10.0.0.tgz",
-      "integrity": "sha512-CVLak9eVDf2jVt5AZTlNe5b4bqHnb8H9h9xfKwUZhLGtb9TbphXhkL0jLaTVYCXPM946wcJg6B+9d9EPKZhAwQ==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/wtf_wikipedia/-/wtf_wikipedia-10.1.4.tgz",
+      "integrity": "sha512-kbBHeCE9vzs057bOEtSprA8wlJkXRH5EbEle+XS27LUivPlZdqSnapo1zOANWXeedpPT7kKLc1OzfhBjSb0JaQ==",
       "hasInstallScript": true,
       "dependencies": {
         "isomorphic-unfetch": "^3.1.0",
@@ -1470,9 +1470,9 @@
       }
     },
     "wtf_wikipedia": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/wtf_wikipedia/-/wtf_wikipedia-10.0.0.tgz",
-      "integrity": "sha512-CVLak9eVDf2jVt5AZTlNe5b4bqHnb8H9h9xfKwUZhLGtb9TbphXhkL0jLaTVYCXPM946wcJg6B+9d9EPKZhAwQ==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/wtf_wikipedia/-/wtf_wikipedia-10.1.4.tgz",
+      "integrity": "sha512-kbBHeCE9vzs057bOEtSprA8wlJkXRH5EbEle+XS27LUivPlZdqSnapo1zOANWXeedpPT7kKLc1OzfhBjSb0JaQ==",
       "requires": {
         "isomorphic-unfetch": "^3.1.0",
         "path-exists-cli": "2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
+        "html-entities": "^2.3.3",
         "jsonfn": "0.31.0",
         "sunday-driver": "1.0.2",
         "wtf_wikipedia": "^10.1.4",
@@ -321,6 +322,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
     },
     "node_modules/indent-string": {
       "version": "5.0.0",
@@ -1123,6 +1129,11 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
     },
     "indent-string": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "dumpster-dip",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "dumpster-dip",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "jsonfn": "0.31.0",
@@ -14,7 +13,6 @@
         "wtf_wikipedia": "10.0.0",
         "yargs": "17.4.1"
       },
-      "devDependencies": {},
       "engines": {
         "node": ">=12.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "jsonfn": "0.31.0",
     "sunday-driver": "1.0.2",
     "wtf_wikipedia": "^10.1.4",
+    "html-entities": "^2.3.3",
     "yargs": "17.4.1"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dumpster-dip",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "parse a wikipedia dump into tiny files",
   "main": "./src/index.js",
   "type": "module",
@@ -32,7 +32,7 @@
   "dependencies": {
     "jsonfn": "0.31.0",
     "sunday-driver": "1.0.2",
-    "wtf_wikipedia": "10.0.0",
+    "wtf_wikipedia": "^10.1.4",
     "yargs": "17.4.1"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,5 @@
     "wtf_wikipedia": "10.0.0",
     "yargs": "17.4.1"
   },
-  "devDependencies": {},
   "license": "MIT"
 }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -6,6 +6,10 @@ export default {
   outputDir: './dip', // (default)
   // which wikipedia namespaces to handle (null will do all)
   namespace: 0, //(default article namespace)
+  // whether to include pages that are redirects
+  redirects: false,
+  // whether to include disambiguiation pages
+  disambiguation: true,
   // define how many concurrent workers to run
   workers: cpuCount, // default is cpu count
   //interval to log status

--- a/src/output/index.js
+++ b/src/output/index.js
@@ -4,8 +4,6 @@ import encodeTitle from './encodeTitle.js'
 
 import path from 'path'
 
-const root = path.resolve()
-
 // recursively create any nested directories
 const writeFile = function (file, json) {
   fs.mkdirSync(path.dirname(file), { recursive: true })
@@ -19,7 +17,7 @@ const append = function (file, txt) {
 // modes:  nested | flat | ndjson
 const output = function (res, opts) {
   const { outputDir, outputMode } = opts
-  let dir = path.join(root, outputDir)
+  let dir = path.resolve(outputDir)
   if (outputMode === 'flat') {
     let title = encodeTitle(res.title)
     dir = path.join(dir, title + '.txt')

--- a/src/pool/Pool.js
+++ b/src/pool/Pool.js
@@ -75,7 +75,7 @@ class Pool extends EventEmitter {
       console.log(grey(row))
       let allDone = this.status.every(obj => obj.finished === true)
       if (allDone === true) {
-        console.log(`Final worker states: ${this.status}`);
+        console.log(`Final worker states: ${JSON.stringify(this.status)}`);
         this.stop()
       }
     }, 500);

--- a/src/pool/Pool.js
+++ b/src/pool/Pool.js
@@ -73,7 +73,7 @@ class Pool extends EventEmitter {
   beat() {
     this.workers.forEach(w => w.postMessage('thump'))
     setTimeout(() => {
-      let row = this.status.map(o => o.written.toLocaleString().padStart('8')).join('   ')
+      let row = this.status.map(o => o.written !== undefined ? o.written.toLocaleString().padStart('8') : "???").join('   ')
       console.log(grey(row))
       let allDone = this.status.every(obj => obj.finished === true)
       if (allDone === true) {

--- a/src/pool/Pool.js
+++ b/src/pool/Pool.js
@@ -36,6 +36,8 @@ class Pool extends EventEmitter {
           outputDir: this.opts.outputDir,
           outputMode: this.opts.outputMode,
           namespace: this.opts.namespace,
+          redirects: this.opts.redirects,
+          disambiguation: this.opts.disambiguation,
           workers: this.opts.workers,
           methods: this.methods,
         }

--- a/src/pool/Pool.js
+++ b/src/pool/Pool.js
@@ -75,6 +75,7 @@ class Pool extends EventEmitter {
       console.log(grey(row))
       let allDone = this.status.every(obj => obj.finished === true)
       if (allDone === true) {
+        console.log(`Final worker states: ${this.status}`);
         this.stop()
       }
     }, 500);

--- a/src/pool/prep.js
+++ b/src/pool/prep.js
@@ -2,7 +2,6 @@
 import fs from 'fs'
 import { red, blue, grey } from '../_lib.js'
 import path from 'path'
-const root = path.resolve()
 
 const checkFile = function (file) {
   if (!file || !fs.existsSync(file)) {
@@ -18,7 +17,7 @@ const checkFile = function (file) {
 }
 
 const makeDir = function (name) {
-  let dir = path.join(root, name)
+  let dir = path.resolve(name)
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir);
   }

--- a/src/pool/prep.js
+++ b/src/pool/prep.js
@@ -19,7 +19,7 @@ const checkFile = function (file) {
 const makeDir = function (name) {
   let dir = path.resolve(name)
   if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir);
+    fs.mkdirSync(dir, { recursive: true });
   }
 }
 export { checkFile, makeDir }

--- a/src/worker/01-reader.js
+++ b/src/worker/01-reader.js
@@ -37,37 +37,34 @@ const readWiki = function (opts, eachPage) {
   const percent = 100 / workers;
   const start = percent * index;
   const end = start + percent;
-  const language = findDbName(file);
-
-  // console.log(`#${index}  - from ${start} to ${end}`)
-  const driver = {
-    file: file,
-    start: `${start}%`,
-    end: `${end}%`,
-    splitter: '</page>',
-    each: (xml, resume) => {
-      let pageTitle = "Unknown page"
-      try {
-        const meta = parseXml(xml);
-        pageTitle = meta.title
-        // console.log("worker", opts.index, "processing", meta.title);
-        meta.wiki = decode(meta.wiki);
-        meta.language = language;
-        eachPage(meta)
-      } catch(e) {
-        console.log(red(`Worker ${opts.index} couldn't process ${pageTitle}: got error ${e}`));
+  return findDbName(file).then(language => {
+    const driver = {
+      file: file,
+      start: `${start}%`,
+      end: `${end}%`,
+      splitter: '</page>',
+      each: (xml, resume) => {
+        let pageTitle = "Unknown page"
+        try {
+          const meta = parseXml(xml);
+          pageTitle = meta.title
+          meta.wiki = decode(meta.wiki);
+          meta.language = language;
+          eachPage(meta)
+        } catch(e) {
+          console.log(red(`Worker ${opts.index} couldn't process ${pageTitle}: got error ${e}`));
+        }
+        resume();
       }
-      resume();
-    }
-  };
-  const p = sundayDriver(driver);
-  p.catch(err => {
-    console.log(red('\n\n========== Worker error!  ====='));
-    console.log('🚨       worker #' + opts.index + '           🚨');
-    console.log(err);
-    console.log('\n\n');
+    };
+    const p = sundayDriver(driver);
+    p.catch(err => {
+      console.log(red('\n\n========== Worker error!  ====='));
+      console.log('🚨       worker #' + opts.index + '           🚨');
+      console.log(err);
+      console.log('\n\n');
+    });
+    return p;
   });
-  return p
-
 }
 export default readWiki

--- a/src/worker/01-reader.js
+++ b/src/worker/01-reader.js
@@ -15,9 +15,14 @@ const readWiki = function (opts, eachPage) {
     end: `${end}%`,
     splitter: '</page>',
     each: (xml, resume) => {
-      let meta = parseXml(xml);
-      meta.wiki = decode(meta.wiki);
-      eachPage(meta)
+      try {
+        let meta = parseXml(xml);
+        // console.log("worker", opts.index, "processing", meta.title);
+        meta.wiki = decode(meta.wiki);
+        eachPage(meta)
+      } catch(e) {
+        console.log(chalk.red(`Worker ${opts.index} encountered ${e} while processing ${meta.title}`));
+      }
       resume();
     }
   };

--- a/src/worker/01-reader.js
+++ b/src/worker/01-reader.js
@@ -1,6 +1,7 @@
 import sundayDriver from 'sunday-driver'
 import parseXml from './02-xml.js'
 import {decode} from 'html-entities'
+import chalk from 'chalk';
 
 const readWiki = function (opts, eachPage) {
   const { index, workers, file } = opts

--- a/src/worker/01-reader.js
+++ b/src/worker/01-reader.js
@@ -11,13 +11,14 @@ const dbNameRegex = /<dbname>(.+)wiki<\/dbname>/;
 async function findDbName(pathToFile) {
   const readable = fs.createReadStream(pathToFile);
   const reader = readline.createInterface({ input: readable });
+  const maxLinesToLookAt = 50;
   const line = await new Promise((resolve, reject) => {
     let i = 0;
     reader.on('line', (line) => {
       i++;
-      if (i > 50) {
+      if (i > maxLinesToLookAt) {
         reader.close();
-        reject("Didn't find dbname in first 3 lines");
+        reject(`Didn't find dbname in first ${maxLinesToLookAt} lines`);
       }
 
       const match = line.match(dbNameRegex)

--- a/src/worker/01-reader.js
+++ b/src/worker/01-reader.js
@@ -17,7 +17,7 @@ const readWiki = function (opts, eachPage) {
     splitter: '</page>',
     each: (xml, resume) => {
       try {
-        let meta = parseXml(xml);
+        const meta = parseXml(xml);
         // console.log("worker", opts.index, "processing", meta.title);
         meta.wiki = decode(meta.wiki);
         eachPage(meta)

--- a/src/worker/01-reader.js
+++ b/src/worker/01-reader.js
@@ -1,5 +1,6 @@
 import sundayDriver from 'sunday-driver'
 import parseXml from './02-xml.js'
+import {decode} from 'html-entities'
 
 const readWiki = function (opts, eachPage) {
   const { index, workers, file } = opts
@@ -15,6 +16,7 @@ const readWiki = function (opts, eachPage) {
     splitter: '</page>',
     each: (xml, resume) => {
       let meta = parseXml(xml);
+      meta.wiki = decode(meta.wiki);
       eachPage(meta)
       resume();
     }

--- a/src/worker/01-reader.js
+++ b/src/worker/01-reader.js
@@ -1,7 +1,7 @@
 import sundayDriver from 'sunday-driver'
 import parseXml from './02-xml.js'
 import {decode} from 'html-entities'
-import chalk from 'chalk';
+import {red} from "../_lib.js"
 
 const readWiki = function (opts, eachPage) {
   const { index, workers, file } = opts
@@ -16,20 +16,22 @@ const readWiki = function (opts, eachPage) {
     end: `${end}%`,
     splitter: '</page>',
     each: (xml, resume) => {
+      let pageTitle = "Unknown page"
       try {
         const meta = parseXml(xml);
+        pageTitle = meta.title
         // console.log("worker", opts.index, "processing", meta.title);
         meta.wiki = decode(meta.wiki);
         eachPage(meta)
       } catch(e) {
-        console.log(chalk.red(`Worker ${opts.index} encountered ${e} while processing ${meta.title}`));
+        console.log(red(`Worker ${opts.index} couldn't process ${pageTitle}: got error ${e}`));
       }
       resume();
     }
   };
   const p = sundayDriver(driver);
   p.catch(err => {
-    console.log(chalk.red('\n\n========== Worker error!  ====='));
+    console.log(red('\n\n========== Worker error!  ====='));
     console.log('🚨       worker #' + opts.index + '           🚨');
     console.log(err);
     console.log('\n\n');


### PR DESCRIPTION
It seems there's a lot of improvements to the dump processing that have been made in dumpster-dive, but not in dumpster-dip. While the ideal solution would be to merge the two projects and make the output options flexible enough to dump to any sink, that's a bigger project than I want to take on now, so I've brought over various tweaks from dumpster-dive and added some of my own. These are ones I found useful while processing an entire dump but happy to submit a subset if you don't think all of them are universally useful.

1. process html entities - this is done in dumpster-dive, but I used the html-entities package instead of a simple find-replace as in dumpster-dive
2. try/catch to avoid hanging the whole process if something fails
3. minor bugfix in the driver to avoid a race condition of no status yet being reported
4. passing in language param so the `url()` is correct based on the dump. Note that I extract dbname rather than xml:lang because of cases like `simple.wikipedia.org`, though this is a slightly leaky abstraction now
5. added redir/disambig params into params being passed so they actually get obeyed
6. logging final state, which is super helpful for debugging
7. made it handle absolute and relative paths equally well; being tied to pwd was a bit restrictive
8. unpinned wtf_wikipedia version and defaulted to current latest