### PR TITLE
Add feature to extract latest revisionID from markup

### DIFF
--- a/src/worker/02-xml.js
+++ b/src/worker/02-xml.js
@@ -2,6 +2,7 @@ const getTitle = /<title>([\s\S]+?)<\/title>/
 const getId = /<id>([0-9]*?)<\/id>/
 const getNS = /<ns>([0-9]*?)<\/ns>/
 const getText = /<text[^>]+xml:space="preserve"([\s\S]*?)<\/text>/
+const getRevisionId = /<revision>[\s\S]*?<id>(\d+)<\/id>/
 
 //doesn't support fancy things like &copy; to ©, etc
 const escapeXML = function (str) {
@@ -36,6 +37,12 @@ const parseXML = function (xml) {
   if (m !== null) {
     m[1] = m[1].replace(/^.*?>/, '')
     page.wiki = escapeXML(m[1])
+  }
+  //get revision id
+  m = xml.match(getRevisionId)
+  console.log(m)
+  if (m !== null) {
+    page.revisionID = m[1]
   }
   return page
 }

--- a/src/worker/02-xml.js
+++ b/src/worker/02-xml.js
@@ -40,7 +40,6 @@ const parseXML = function (xml) {
   }
   //get revision id
   m = xml.match(getRevisionId)
-  console.log(m)
   if (m !== null) {
     page.revisionID = m[1]
   }


### PR DESCRIPTION
This change adds a feature to extract the revision id from the wikidump markup.

This is useful for checking for changes between two different wikidumps if you're so inclined.

Depends on https://github.com/spencermountain/wtf_wikipedia/pull/568